### PR TITLE
Add several tests involving slashable data

### DIFF
--- a/tests/generated/duplicate_pubkey_slashable_attestation.json
+++ b/tests/generated/duplicate_pubkey_slashable_attestation.json
@@ -1,0 +1,70 @@
+{
+  "name": "duplicate_pubkey_slashable_attestation",
+  "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "steps": [
+    {
+      "should_succeed": true,
+      "allow_partial_import": true,
+      "interchange": {
+        "metadata": {
+          "interchange_format_version": "5",
+          "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "data": [
+          {
+            "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+            "signed_blocks": [],
+            "signed_attestations": [
+              {
+                "source_epoch": "0",
+                "target_epoch": "3",
+                "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000003"
+              }
+            ]
+          },
+          {
+            "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+            "signed_blocks": [],
+            "signed_attestations": [
+              {
+                "source_epoch": "1",
+                "target_epoch": "2"
+              }
+            ]
+          }
+        ]
+      },
+      "blocks": [],
+      "attestations": [
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "0",
+          "target_epoch": "1",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "0",
+          "target_epoch": "2",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "0",
+          "target_epoch": "4",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "1",
+          "target_epoch": "4",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/generated/duplicate_pubkey_slashable_block.json
+++ b/tests/generated/duplicate_pubkey_slashable_block.json
@@ -1,0 +1,61 @@
+{
+  "name": "duplicate_pubkey_slashable_block",
+  "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "steps": [
+    {
+      "should_succeed": true,
+      "allow_partial_import": true,
+      "interchange": {
+        "metadata": {
+          "interchange_format_version": "5",
+          "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "data": [
+          {
+            "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+            "signed_blocks": [
+              {
+                "slot": "10"
+              }
+            ],
+            "signed_attestations": [
+              {
+                "source_epoch": "0",
+                "target_epoch": "2"
+              }
+            ]
+          },
+          {
+            "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+            "signed_blocks": [
+              {
+                "slot": "10"
+              }
+            ],
+            "signed_attestations": [
+              {
+                "source_epoch": "1",
+                "target_epoch": "3"
+              }
+            ]
+          }
+        ]
+      },
+      "blocks": [
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "slot": "10",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "slot": "11",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": true
+        }
+      ],
+      "attestations": []
+    }
+  ]
+}

--- a/tests/generated/multiple_interchanges_single_validator_fail_iff_imported.json
+++ b/tests/generated/multiple_interchanges_single_validator_fail_iff_imported.json
@@ -1,0 +1,68 @@
+{
+  "name": "multiple_interchanges_single_validator_fail_iff_imported",
+  "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "steps": [
+    {
+      "should_succeed": true,
+      "allow_partial_import": false,
+      "interchange": {
+        "metadata": {
+          "interchange_format_version": "5",
+          "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "data": [
+          {
+            "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+            "signed_blocks": [
+              {
+                "slot": "40"
+              }
+            ],
+            "signed_attestations": []
+          }
+        ]
+      },
+      "blocks": [],
+      "attestations": []
+    },
+    {
+      "should_succeed": true,
+      "allow_partial_import": true,
+      "interchange": {
+        "metadata": {
+          "interchange_format_version": "5",
+          "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "data": [
+          {
+            "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+            "signed_blocks": [
+              {
+                "slot": "20"
+              },
+              {
+                "slot": "50"
+              }
+            ],
+            "signed_attestations": []
+          }
+        ]
+      },
+      "blocks": [
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "slot": "20",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "slot": "50",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        }
+      ],
+      "attestations": []
+    }
+  ]
+}

--- a/tests/generated/single_validator_source_greater_than_target_sensible_iff_minified.json
+++ b/tests/generated/single_validator_source_greater_than_target_sensible_iff_minified.json
@@ -1,0 +1,49 @@
+{
+  "name": "single_validator_source_greater_than_target_sensible_iff_minified",
+  "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "steps": [
+    {
+      "should_succeed": true,
+      "allow_partial_import": true,
+      "interchange": {
+        "metadata": {
+          "interchange_format_version": "5",
+          "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "data": [
+          {
+            "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+            "signed_blocks": [],
+            "signed_attestations": [
+              {
+                "source_epoch": "5",
+                "target_epoch": "2"
+              },
+              {
+                "source_epoch": "6",
+                "target_epoch": "7"
+              }
+            ]
+          }
+        ]
+      },
+      "blocks": [],
+      "attestations": [
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "5",
+          "target_epoch": "8",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "6",
+          "target_epoch": "8",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/generated/single_validator_source_greater_than_target_surrounded.json
+++ b/tests/generated/single_validator_source_greater_than_target_surrounded.json
@@ -1,0 +1,38 @@
+{
+  "name": "single_validator_source_greater_than_target_surrounded",
+  "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "steps": [
+    {
+      "should_succeed": true,
+      "allow_partial_import": true,
+      "interchange": {
+        "metadata": {
+          "interchange_format_version": "5",
+          "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "data": [
+          {
+            "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+            "signed_blocks": [],
+            "signed_attestations": [
+              {
+                "source_epoch": "5",
+                "target_epoch": "2"
+              }
+            ]
+          }
+        ]
+      },
+      "blocks": [],
+      "attestations": [
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "6",
+          "target_epoch": "1",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/generated/single_validator_source_greater_than_target_surrounding.json
+++ b/tests/generated/single_validator_source_greater_than_target_surrounding.json
@@ -1,0 +1,38 @@
+{
+  "name": "single_validator_source_greater_than_target_surrounding",
+  "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "steps": [
+    {
+      "should_succeed": true,
+      "allow_partial_import": true,
+      "interchange": {
+        "metadata": {
+          "interchange_format_version": "5",
+          "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "data": [
+          {
+            "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+            "signed_blocks": [],
+            "signed_attestations": [
+              {
+                "source_epoch": "5",
+                "target_epoch": "2"
+              }
+            ]
+          }
+        ]
+      },
+      "blocks": [],
+      "attestations": [
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "3",
+          "target_epoch": "4",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Tests involving:

- Attestations with source greater than target (i.e. backwards)
- Duplicate entries for the same pubkey in a single interchange, where one of the entries contains slashable data
- Multiple interchanges, where the attestations checked after the import of the second are only slashable if the second interchange was imported, but it would also be reasonable _not_ to import the second interchange (i.e. `multiple_interchanges_single_validator_fail_iff_imported`)