### PR TITLE
New tests with multiple files

### DIFF
--- a/tests/generated/multiple_interchanges_multiple_validators_repeat_idem.json
+++ b/tests/generated/multiple_interchanges_multiple_validators_repeat_idem.json
@@ -1,0 +1,176 @@
+{
+  "name": "multiple_interchanges_multiple_validators_repeat_idem",
+  "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "steps": [
+    {
+      "should_succeed": true,
+      "contains_slashable_data": false,
+      "interchange": {
+        "metadata": {
+          "interchange_format_version": "5",
+          "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "data": [
+          {
+            "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+            "signed_blocks": [
+              {
+                "slot": "2"
+              },
+              {
+                "slot": "4"
+              },
+              {
+                "slot": "6"
+              }
+            ],
+            "signed_attestations": [
+              {
+                "source_epoch": "0",
+                "target_epoch": "1"
+              },
+              {
+                "source_epoch": "1",
+                "target_epoch": "2"
+              }
+            ]
+          },
+          {
+            "pubkey": "0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b",
+            "signed_blocks": [
+              {
+                "slot": "8"
+              },
+              {
+                "slot": "10"
+              },
+              {
+                "slot": "12"
+              }
+            ],
+            "signed_attestations": [
+              {
+                "source_epoch": "0",
+                "target_epoch": "1"
+              },
+              {
+                "source_epoch": "0",
+                "target_epoch": "3"
+              }
+            ]
+          }
+        ]
+      },
+      "blocks": [],
+      "attestations": []
+    },
+    {
+      "should_succeed": true,
+      "contains_slashable_data": true,
+      "interchange": {
+        "metadata": {
+          "interchange_format_version": "5",
+          "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "data": [
+          {
+            "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+            "signed_blocks": [
+              {
+                "slot": "2"
+              },
+              {
+                "slot": "4"
+              },
+              {
+                "slot": "6"
+              }
+            ],
+            "signed_attestations": [
+              {
+                "source_epoch": "0",
+                "target_epoch": "1"
+              },
+              {
+                "source_epoch": "1",
+                "target_epoch": "2"
+              }
+            ]
+          },
+          {
+            "pubkey": "0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b",
+            "signed_blocks": [
+              {
+                "slot": "8"
+              },
+              {
+                "slot": "10"
+              },
+              {
+                "slot": "12"
+              }
+            ],
+            "signed_attestations": [
+              {
+                "source_epoch": "0",
+                "target_epoch": "1"
+              },
+              {
+                "source_epoch": "0",
+                "target_epoch": "3"
+              }
+            ]
+          }
+        ]
+      },
+      "blocks": [
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "slot": "0",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "slot": "3",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": true
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "slot": "7",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": true
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "slot": "3",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": true
+        },
+        {
+          "pubkey": "0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b",
+          "slot": "0",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        }
+      ],
+      "attestations": [
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "0",
+          "target_epoch": "4",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b",
+          "source_epoch": "0",
+          "target_epoch": "4",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/generated/multiple_interchanges_overlapping_validators_merge_stale.json
+++ b/tests/generated/multiple_interchanges_overlapping_validators_merge_stale.json
@@ -1,0 +1,219 @@
+{
+  "name": "multiple_interchanges_overlapping_validators_merge_stale",
+  "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "steps": [
+    {
+      "should_succeed": true,
+      "contains_slashable_data": false,
+      "interchange": {
+        "metadata": {
+          "interchange_format_version": "5",
+          "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "data": [
+          {
+            "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+            "signed_blocks": [
+              {
+                "slot": "100"
+              }
+            ],
+            "signed_attestations": [
+              {
+                "source_epoch": "12",
+                "target_epoch": "13"
+              }
+            ]
+          },
+          {
+            "pubkey": "0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b",
+            "signed_blocks": [
+              {
+                "slot": "101"
+              }
+            ],
+            "signed_attestations": [
+              {
+                "source_epoch": "12",
+                "target_epoch": "13"
+              }
+            ]
+          },
+          {
+            "pubkey": "0xa3a32b0f8b4ddb83f1a0a853d81dd725dfe577d4f4c3db8ece52ce2b026eca84815c1a7e8e92a4de3d755733bf7e4a9b",
+            "signed_blocks": [
+              {
+                "slot": "4"
+              }
+            ],
+            "signed_attestations": [
+              {
+                "source_epoch": "4",
+                "target_epoch": "5"
+              }
+            ]
+          }
+        ]
+      },
+      "blocks": [],
+      "attestations": []
+    },
+    {
+      "should_succeed": true,
+      "contains_slashable_data": true,
+      "interchange": {
+        "metadata": {
+          "interchange_format_version": "5",
+          "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "data": [
+          {
+            "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+            "signed_blocks": [
+              {
+                "slot": "2"
+              }
+            ],
+            "signed_attestations": [
+              {
+                "source_epoch": "4",
+                "target_epoch": "5"
+              }
+            ]
+          },
+          {
+            "pubkey": "0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b",
+            "signed_blocks": [
+              {
+                "slot": "3"
+              }
+            ],
+            "signed_attestations": [
+              {
+                "source_epoch": "3",
+                "target_epoch": "4"
+              }
+            ]
+          },
+          {
+            "pubkey": "0xa3a32b0f8b4ddb83f1a0a853d81dd725dfe577d4f4c3db8ece52ce2b026eca84815c1a7e8e92a4de3d755733bf7e4a9b",
+            "signed_blocks": [
+              {
+                "slot": "102"
+              }
+            ],
+            "signed_attestations": [
+              {
+                "source_epoch": "12",
+                "target_epoch": "13"
+              }
+            ]
+          }
+        ]
+      },
+      "blocks": [
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "slot": "100",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b",
+          "slot": "101",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xa3a32b0f8b4ddb83f1a0a853d81dd725dfe577d4f4c3db8ece52ce2b026eca84815c1a7e8e92a4de3d755733bf7e4a9b",
+          "slot": "102",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "slot": "103",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": true
+        },
+        {
+          "pubkey": "0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b",
+          "slot": "104",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": true
+        },
+        {
+          "pubkey": "0xa3a32b0f8b4ddb83f1a0a853d81dd725dfe577d4f4c3db8ece52ce2b026eca84815c1a7e8e92a4de3d755733bf7e4a9b",
+          "slot": "105",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": true
+        }
+      ],
+      "attestations": [
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "12",
+          "target_epoch": "13",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "11",
+          "target_epoch": "14",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b",
+          "source_epoch": "12",
+          "target_epoch": "13",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b",
+          "source_epoch": "11",
+          "target_epoch": "14",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xa3a32b0f8b4ddb83f1a0a853d81dd725dfe577d4f4c3db8ece52ce2b026eca84815c1a7e8e92a4de3d755733bf7e4a9b",
+          "source_epoch": "12",
+          "target_epoch": "13",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xa3a32b0f8b4ddb83f1a0a853d81dd725dfe577d4f4c3db8ece52ce2b026eca84815c1a7e8e92a4de3d755733bf7e4a9b",
+          "source_epoch": "11",
+          "target_epoch": "14",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "12",
+          "target_epoch": "14",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": true
+        },
+        {
+          "pubkey": "0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b",
+          "source_epoch": "13",
+          "target_epoch": "14",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": true
+        },
+        {
+          "pubkey": "0xa3a32b0f8b4ddb83f1a0a853d81dd725dfe577d4f4c3db8ece52ce2b026eca84815c1a7e8e92a4de3d755733bf7e4a9b",
+          "source_epoch": "13",
+          "target_epoch": "14",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/generated/multiple_interchanges_overlapping_validators_repeat_idem.json
+++ b/tests/generated/multiple_interchanges_overlapping_validators_repeat_idem.json
@@ -1,0 +1,214 @@
+{
+  "name": "multiple_interchanges_overlapping_validators_repeat_idem",
+  "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "steps": [
+    {
+      "should_succeed": true,
+      "contains_slashable_data": false,
+      "interchange": {
+        "metadata": {
+          "interchange_format_version": "5",
+          "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "data": [
+          {
+            "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+            "signed_blocks": [
+              {
+                "slot": "2"
+              },
+              {
+                "slot": "4"
+              },
+              {
+                "slot": "6"
+              }
+            ],
+            "signed_attestations": [
+              {
+                "source_epoch": "0",
+                "target_epoch": "1"
+              },
+              {
+                "source_epoch": "1",
+                "target_epoch": "2"
+              }
+            ]
+          },
+          {
+            "pubkey": "0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b",
+            "signed_blocks": [
+              {
+                "slot": "8"
+              },
+              {
+                "slot": "10"
+              },
+              {
+                "slot": "12"
+              }
+            ],
+            "signed_attestations": [
+              {
+                "source_epoch": "0",
+                "target_epoch": "1"
+              },
+              {
+                "source_epoch": "0",
+                "target_epoch": "3"
+              }
+            ]
+          }
+        ]
+      },
+      "blocks": [],
+      "attestations": []
+    },
+    {
+      "should_succeed": true,
+      "contains_slashable_data": true,
+      "interchange": {
+        "metadata": {
+          "interchange_format_version": "5",
+          "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "data": [
+          {
+            "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+            "signed_blocks": [
+              {
+                "slot": "2"
+              },
+              {
+                "slot": "4"
+              },
+              {
+                "slot": "6"
+              }
+            ],
+            "signed_attestations": [
+              {
+                "source_epoch": "0",
+                "target_epoch": "1"
+              },
+              {
+                "source_epoch": "1",
+                "target_epoch": "2"
+              }
+            ]
+          },
+          {
+            "pubkey": "0xa3a32b0f8b4ddb83f1a0a853d81dd725dfe577d4f4c3db8ece52ce2b026eca84815c1a7e8e92a4de3d755733bf7e4a9b",
+            "signed_blocks": [
+              {
+                "slot": "8"
+              },
+              {
+                "slot": "10"
+              },
+              {
+                "slot": "12"
+              }
+            ],
+            "signed_attestations": [
+              {
+                "source_epoch": "0",
+                "target_epoch": "1"
+              },
+              {
+                "source_epoch": "0",
+                "target_epoch": "3"
+              }
+            ]
+          }
+        ]
+      },
+      "blocks": [],
+      "attestations": []
+    },
+    {
+      "should_succeed": true,
+      "contains_slashable_data": true,
+      "interchange": {
+        "metadata": {
+          "interchange_format_version": "5",
+          "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "data": [
+          {
+            "pubkey": "0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b",
+            "signed_blocks": [
+              {
+                "slot": "8"
+              },
+              {
+                "slot": "10"
+              },
+              {
+                "slot": "12"
+              }
+            ],
+            "signed_attestations": [
+              {
+                "source_epoch": "0",
+                "target_epoch": "1"
+              },
+              {
+                "source_epoch": "0",
+                "target_epoch": "3"
+              }
+            ]
+          },
+          {
+            "pubkey": "0xa3a32b0f8b4ddb83f1a0a853d81dd725dfe577d4f4c3db8ece52ce2b026eca84815c1a7e8e92a4de3d755733bf7e4a9b",
+            "signed_blocks": [
+              {
+                "slot": "8"
+              },
+              {
+                "slot": "10"
+              },
+              {
+                "slot": "12"
+              }
+            ],
+            "signed_attestations": [
+              {
+                "source_epoch": "0",
+                "target_epoch": "1"
+              },
+              {
+                "source_epoch": "0",
+                "target_epoch": "3"
+              }
+            ]
+          }
+        ]
+      },
+      "blocks": [],
+      "attestations": [
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "0",
+          "target_epoch": "4",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xb89bebc699769726a318c8e9971bd3171297c61aea4a6578a7a4f94b547dcba5bac16a89108b6b6a1fe3695d1a874a0b",
+          "source_epoch": "1",
+          "target_epoch": "2",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xa3a32b0f8b4ddb83f1a0a853d81dd725dfe577d4f4c3db8ece52ce2b026eca84815c1a7e8e92a4de3d755733bf7e4a9b",
+          "source_epoch": "1",
+          "target_epoch": "2",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        }
+      ]
+    }
+  ]
+}

--- a/tests/generated/multiple_interchanges_single_validator_first_surrounds_second.json
+++ b/tests/generated/multiple_interchanges_single_validator_first_surrounds_second.json
@@ -1,0 +1,90 @@
+{
+  "name": "multiple_interchanges_single_validator_first_surrounds_second",
+  "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "steps": [
+    {
+      "should_succeed": true,
+      "contains_slashable_data": false,
+      "interchange": {
+        "metadata": {
+          "interchange_format_version": "5",
+          "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "data": [
+          {
+            "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+            "signed_blocks": [],
+            "signed_attestations": [
+              {
+                "source_epoch": "9",
+                "target_epoch": "21"
+              }
+            ]
+          }
+        ]
+      },
+      "blocks": [],
+      "attestations": []
+    },
+    {
+      "should_succeed": true,
+      "contains_slashable_data": true,
+      "interchange": {
+        "metadata": {
+          "interchange_format_version": "5",
+          "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "data": [
+          {
+            "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+            "signed_blocks": [],
+            "signed_attestations": [
+              {
+                "source_epoch": "10",
+                "target_epoch": "20"
+              }
+            ]
+          }
+        ]
+      },
+      "blocks": [],
+      "attestations": [
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "10",
+          "target_epoch": "20",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "10",
+          "target_epoch": "21",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "9",
+          "target_epoch": "21",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "9",
+          "target_epoch": "22",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "10",
+          "target_epoch": "22",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/generated/multiple_interchanges_single_validator_second_surrounds_first.json
+++ b/tests/generated/multiple_interchanges_single_validator_second_surrounds_first.json
@@ -1,0 +1,90 @@
+{
+  "name": "multiple_interchanges_single_validator_second_surrounds_first",
+  "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "steps": [
+    {
+      "should_succeed": true,
+      "contains_slashable_data": false,
+      "interchange": {
+        "metadata": {
+          "interchange_format_version": "5",
+          "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "data": [
+          {
+            "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+            "signed_blocks": [],
+            "signed_attestations": [
+              {
+                "source_epoch": "10",
+                "target_epoch": "20"
+              }
+            ]
+          }
+        ]
+      },
+      "blocks": [],
+      "attestations": []
+    },
+    {
+      "should_succeed": true,
+      "contains_slashable_data": true,
+      "interchange": {
+        "metadata": {
+          "interchange_format_version": "5",
+          "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "data": [
+          {
+            "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+            "signed_blocks": [],
+            "signed_attestations": [
+              {
+                "source_epoch": "9",
+                "target_epoch": "21"
+              }
+            ]
+          }
+        ]
+      },
+      "blocks": [],
+      "attestations": [
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "10",
+          "target_epoch": "20",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "10",
+          "target_epoch": "21",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "9",
+          "target_epoch": "21",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "9",
+          "target_epoch": "22",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "10",
+          "target_epoch": "22",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/generated/multiple_interchanges_single_validator_single_att_out_of_order.json
+++ b/tests/generated/multiple_interchanges_single_validator_single_att_out_of_order.json
@@ -1,0 +1,83 @@
+{
+  "name": "multiple_interchanges_single_validator_single_att_out_of_order",
+  "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "steps": [
+    {
+      "should_succeed": true,
+      "contains_slashable_data": false,
+      "interchange": {
+        "metadata": {
+          "interchange_format_version": "5",
+          "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "data": [
+          {
+            "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+            "signed_blocks": [],
+            "signed_attestations": [
+              {
+                "source_epoch": "12",
+                "target_epoch": "13"
+              }
+            ]
+          }
+        ]
+      },
+      "blocks": [],
+      "attestations": []
+    },
+    {
+      "should_succeed": true,
+      "contains_slashable_data": true,
+      "interchange": {
+        "metadata": {
+          "interchange_format_version": "5",
+          "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "data": [
+          {
+            "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+            "signed_blocks": [],
+            "signed_attestations": [
+              {
+                "source_epoch": "10",
+                "target_epoch": "11"
+              }
+            ]
+          }
+        ]
+      },
+      "blocks": [],
+      "attestations": [
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "10",
+          "target_epoch": "14",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "12",
+          "target_epoch": "13",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": false
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "12",
+          "target_epoch": "14",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": true
+        },
+        {
+          "pubkey": "0xa99a76ed7796f7be22d5b7e85deeb7c5677e88e511e0b337618f8c4eb61349b4bf2d153f649f7b53359fe8b94a38e44c",
+          "source_epoch": "13",
+          "target_epoch": "15",
+          "signing_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
+          "should_succeed": true
+        }
+      ]
+    }
+  ]
+}

--- a/tests/generated/multiple_interchanges_single_validator_single_block_out_of_order.json
+++ b/tests/generated/multiple_interchanges_single_validator_single_block_out_of_order.json
@@ -1,5 +1,5 @@
 {
-  "name": "multiple_interchanges_single_validator_single_message_out_of_order",
+  "name": "multiple_interchanges_single_validator_single_block_out_of_order",
   "genesis_validators_root": "0x0000000000000000000000000000000000000000000000000000000000000000",
   "steps": [
     {


### PR DESCRIPTION
Add some new tests with multiple interchange files, some including slashable data, and some including overlapping sets of validators with stale messages (which naively appear slashable, so are categorised as `contains_slashable_data`).